### PR TITLE
Fix three typos in the Introduction

### DIFF
--- a/include/introduction.tex
+++ b/include/introduction.tex
@@ -14,12 +14,12 @@ true) or ``$\Diamond p \lif \Box\Diamond p$'' (if $p$ is possible,
 it is necessarily possible).
 
 The operators $\Box$ and $\Diamond$ are \emph{intensional}. This means
-that whether $\Box !A$ or $\Diamond !A$ hold does not just depend on
+that whether $\Box !A$ or $\Diamond !A$ holds does not just depend on
 whether $!A$ holds or doesn't.  An operator which is not intensional
 is \emph{extensional}. Negation is extensional: $\lnot !A$ holds iff
 $!A$ does not; so whether $\lnot !A$ holds only depends on whether
 $!A$ holds or doesn't. $\Box$ and $\Diamond$ are not like that:
-whether $\Box !A$ or $\Diamond !A$ hold depends also on the meaning
+whether $\Box !A$ or $\Diamond !A$ holds depends also on the meaning
 of~$!A$.  While ordinary truth-functional semantics is enough to deal
 with extensional operators, intensional operators like $\Box$ and
 $\Diamond$ require a different kind of semantics. One such semantics

--- a/include/introduction.tex
+++ b/include/introduction.tex
@@ -19,7 +19,7 @@ whether $!A$ holds or doesn't.  An operator which is not intensional
 is \emph{extensional}. Negation is extensional: $\lnot !A$ holds iff
 $!A$ does not; so whether $\lnot !A$ holds only depends on whether
 $!A$ holds or doesn't. $\Box$ and $\Diamond$ are not like that:
-whether $\Box !A$ or $\Diamond !A$ holds depends also on the meaning
+whether $\Box !A$ or $\Diamond !A$ hold depends also on the meaning
 of~$!A$.  While ordinary truth-functional semantics is enough to deal
 with extensional operators, intensional operators like $\Box$ and
 $\Diamond$ require a different kind of semantics. One such semantics
@@ -54,7 +54,7 @@ interpretations.
 
 In order to deal with different interpretations of the modal
 operators, the semantics is extended by a relation between worlds, the
-so-called accessibility relation.  Then $\mSat{M}{\Box !A}[w]$ if
+so-called accessibility relation.  Then $\mSat{M}{\Box !A}[w]$ iff
 $\mSat{M}{!A}[v]$ for all worlds~$v$ which are accessible from~$w$.
 The resulting semantics is very versatile and powerful, and the basic
 idea can be used to provide semantic interpretations for logics based
@@ -84,7 +84,7 @@ deals with intuitionistic logic. Here we discuss natural deduction and
 axiomatic derivations, relational and topological semantics, and
 soundness and completeness of the proof systems. The third part deals
 with the Lewis-Stalnaker semantics of counterfactual conditionals. The
-appendices discusses some ideas and results from set theory and the
+appendices discuss some ideas and results from set theory and the
 theory of relations that's crucial to the relational semantics, and
-reviews syntax, semantics, and proof theory of classical propositional
+review syntax, semantics, and proof theory of classical propositional
 logic.


### PR DESCRIPTION
I believe these (tiny) changes are beneficial:

Second paragraph: "whether X or Y holds" -> "hold" (also for consistency
with the same sentence four lines above).
Fifth paragraph: "if" -> "iff".
Last paragraph: "The appendices discusses .. reviews" -> "discuss ..
review" (plural is used here).